### PR TITLE
Update to railway cli v3.x

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2183,7 +2183,7 @@ function run() {
                     core.debug("Railway CLI Path: " + resolvedPath);
                 }
             });
-            yield exec.exec("railway", ["version"]);
+            yield exec.exec("railway", ["--version"]);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,102 @@
 {
   "name": "@madebythepinshub/setup-railway-cli-action",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@madebythepinshub/setup-railway-cli-action",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^1.3.0",
+        "@actions/exec": "^1.0.4",
+        "typescript": "^4.3.2",
+        "which": "^2.0.2"
+      },
+      "devDependencies": {
+        "@types/node": "^15.6.1",
+        "@vercel/ncc": "^0.28.6",
+        "prettier": "^2.3.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-xxtX0Cwdhb8LcgatfJkokqT8KzPvcIbwL9xpLU09nOwBzaStbfm0dNncsP0M4us+EpoPdWy7vbzU5vSOH7K6pg=="
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.0.4.tgz",
+      "integrity": "sha512-4DPChWow9yc9W3WqEbUj8Nr86xkpyE29ZzWjXucHItclLbEW6jr80Zx4nqv18QL6KK65+cifiQZXvnqgTV6oHw==",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.0.tgz",
+      "integrity": "sha512-PspSX7Z9zh2Fyyuf3F6BsYeXcYHfc/VJ1vwy2vouas95efHVd42M6UfBFRs+jY0uiMDXhAoUtATn9g2r1MaWBQ=="
+    },
+    "node_modules/@types/node": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==",
+      "dev": true
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.28.6",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.28.6.tgz",
+      "integrity": "sha512-t4BoSSuyK8BZaUE0gV18V6bkFs4st7baumtFGa50dv1tMu2GDBEBF8sUZaKBdKiL6DzJ2D2+XVCwYWWDcQOYdQ==",
+      "dev": true,
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "node_modules/prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  },
   "dependencies": {
     "@actions/core": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madebythepinshub/setup-railway-cli-action",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Set up Railway CLI in GitHub Actions",
   "main": "src/main.ts",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,7 @@ async function run(): Promise<void> {
         core.debug("Railway CLI Path: " + resolvedPath);
       }
     });
-    await exec.exec("railway", ["version"]);
+    await exec.exec("railway", ["--version"]);
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
Hi, hope you are well...

This actions is not working for cli v3.x because the railway new release changed the way to get version.

As the last step of railway installation request the railway version, it is breaking all the process. For railway version 3.x, we should run `railway --version` instead of `railway version`.

I didn't test the action, because I didn't find a way to do that. Please, let me know how can test it if want to.

Thank you in advanced!